### PR TITLE
Fix clang build issues and add travis build test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: c
+before_install:
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test  # gcc v4.8
+    - sudo apt-get -qq update
+    - if [ "$CC" = "gcc" ]; then sudo apt-get install -qq g++-4.8; fi
+    - if [ "$CC" = "gcc" ]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90; fi
+    - if [ "$CC" = "clang" ]; then sudo apt-get install -qq clang-3.4; fi
+    - sudo apt-get build-dep qemu
+    - git submodule update --init --recursive
+    - export QSIM_PREFIX=`pwd`
+    - mkdir build
+    - cd build
+    - ../arm64-build.sh release
+    - cd ..
+script:
+    - make -j2
+install:
+    - make install
+compiler:
+- clang
+- gcc
+git:
+  submodules: true
+notifications:
+    email:
+        recipients:
+            - bobby.prani@gmail.com
+        on_success: change
+        on_failure: always

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # This work is licensed under the terms of the GNU GPL, version 2. See the    #
 # COPYING file in the top-level directory.                                    #
 ###############################################################################
-CXXFLAGS ?= -O0 -g -Idistorm/
+CXXFLAGS ?= -O2 -g -Idistorm/
 QSIM_PREFIX ?= /usr/local
 LDFLAGS = -L./
 LDLIBS = -lqsim -ldl

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-QSIM 0.1 Quickstart Guide
+qsim [![Build Status](https://travis-ci.org/pranith/qsim.svg?branch=unit_tests)](https://travis-ci.org/pranith/qsim)
 =========================
 
   1. See building/installation instructions in INSTALL.

--- a/arm64-build.sh
+++ b/arm64-build.sh
@@ -11,10 +11,11 @@ if [ -z $1 ]; then
   debug_flags="--enable-debug --enable-debug-tcg --enable-debug-info"
 fi
 
-QEMU_CFLAGS="-DQSIM_ARM64 -I${QSIM_PREFIX} -shared -m64 -g  -Werror -fPIC -m64 -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -Wstrict-prototypes -Wredundant-decls -Wall -Wundef -Wwrite-strings -Wmissing-prototypes -fno-strict-aliasing -fno-common -Wendif-labels -Wmissing-include-dirs -Wempty-body -Wnested-externs -Wformat-security -Wformat-y2k -Winit-self -Wignored-qualifiers -Wold-style-declaration -Wold-style-definition -Wtype-limits -fstack-protector-all -Wno-uninitialized" ../qemu/configure --target-list=aarch64-softmmu --disable-pie $debug_flags
+mkdir -p $QSIM_PREFIX/lib/
+QEMU_CFLAGS="-DQSIM_ARM64 -I${QSIM_PREFIX} -m64 -g -Werror -fPIC -m64 -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -Wstrict-prototypes -Wredundant-decls -Wall -Wundef -Wwrite-strings -Wmissing-prototypes -fno-strict-aliasing -fno-common -Wendif-labels -Wmissing-include-dirs -Wempty-body -Wnested-externs -Wformat-security -Wformat-y2k -Winit-self -Wignored-qualifiers -Wtype-limits -fstack-protector-all -Wno-uninitialized" ../qemu/configure --extra-ldflags=-shared --target-list=aarch64-softmmu --disable-pie $debug_flags
 make -j16
 cp aarch64-softmmu/qemu-system-aarch64 $QSIM_PREFIX/lib/libqemu-qsim-a64.so
 rm -f vl.o
-QEMU_CFLAGS="-DQSIM_X86 -I${QSIM_PREFIX} -shared -m64 -g  -Werror -fPIC -m64 -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -Wstrict-prototypes -Wredundant-decls -Wall -Wundef -Wwrite-strings -Wmissing-prototypes -fno-strict-aliasing -fno-common -Wendif-labels -Wmissing-include-dirs -Wempty-body -Wnested-externs -Wformat-security -Wformat-y2k -Winit-self -Wignored-qualifiers -Wold-style-declaration -Wold-style-definition -Wtype-limits -fstack-protector-all -Wno-uninitialized" ../qemu/configure --target-list=x86_64-softmmu --disable-pie $debug_flags
+QEMU_CFLAGS="-DQSIM_X86 -I${QSIM_PREFIX} -m64 -g -Werror -fPIC -m64 -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -Wstrict-prototypes -Wredundant-decls -Wall -Wundef -Wwrite-strings -Wmissing-prototypes -fno-strict-aliasing -fno-common -Wendif-labels -Wmissing-include-dirs -Wempty-body -Wnested-externs -Wformat-security -Wformat-y2k -Winit-self -Wignored-qualifiers -Wtype-limits -fstack-protector-all -Wno-uninitialized" ../qemu/configure --extra-ldflags=-shared --target-list=x86_64-softmmu --disable-pie $debug_flags
 make -j16
 cp x86_64-softmmu/qemu-system-x86_64 $QSIM_PREFIX/lib/libqemu-qsim-x86.so

--- a/qsim-arm64-regs.h
+++ b/qsim-arm64-regs.h
@@ -1,5 +1,5 @@
 #ifndef __ARM64_REGS_H
-#define __ARM46_REGS_H
+#define __ARM64_REGS_H
 
 enum _a64_regs {
     QSIM_X0 = 0, QSIM_X1, QSIM_X2, QSIM_X3,

--- a/qsim-func.h
+++ b/qsim-func.h
@@ -1,4 +1,4 @@
-#ifndef __VM_FUNC__H
+#ifndef __VM_FUNC_H
 #define __VM_FUNC_H
 /*****************************************************************************\
 * Qemu Simulation Framework (qsim)                                            *

--- a/qsim.cpp
+++ b/qsim.cpp
@@ -474,6 +474,8 @@ unsigned Qsim::OSDomain::run(uint16_t i, unsigned n) {
   pthread_mutex_unlock(&pending_ipis_mutex);
 
   if (running[i]) { return cpus[i]->run(n); } 
+
+  return 0;
 }
 
 void Qsim::OSDomain::connect_console(std::ostream& s) {
@@ -580,6 +582,8 @@ void Qsim::OSDomain::unset_app_end_cb(end_cb_handle_t h) {
 
 int Qsim::OSDomain::atomic_cb_s(int cpu_id) {
   osdomains[cpu_id >> 16]->atomic_cb(cpu_id & 0xffff);
+
+  return 0;
 }
 
 int Qsim::OSDomain::atomic_cb(int cpu_id) {
@@ -688,6 +692,8 @@ void Qsim::OSDomain::trans_cb(int cpu_id) {
 
 int Qsim::OSDomain::magic_cb_s(int cpu_id, uint64_t rax) {
   osdomains[cpu_id >> 16]->magic_cb(cpu_id & 0xffff, rax);
+
+  return 0;
 }
 
 int Qsim::OSDomain::magic_cb(int cpu_id, uint64_t rax) {


### PR DESCRIPTION
Fix all the warnings reported by Clang(most of which were scary) and add automatic build testing infrastructure. We need to extend this infrastructure to include unit testing in the future.